### PR TITLE
Update button to "save changes"

### DIFF
--- a/blog-posts/manage-dev-to-blog-posts-with-continuous-deployment/manage-dev-to-blog-posts-with-continuous-deployment.md
+++ b/blog-posts/manage-dev-to-blog-posts-with-continuous-deployment/manage-dev-to-blog-posts-with-continuous-deployment.md
@@ -106,7 +106,7 @@ Example:
 ]
 ```
 
-There's no easy way to manage the creation of an article (yet?) but it's a quick / one time thing. Go to https://dev.to and click at the top on the "write a post" button. Write a title (that can be updated later) and press the "save draft" button. This way the article is not published yet and only available to you.
+There's no easy way to manage the creation of an article (yet?) but it's a quick / one time thing. Go to https://dev.to and click at the top on the "write a post" button. Write a title (that can be updated later) and press the "save changes" button. This way the article is not published yet and only available to you.
 
 As dev.to doesn't display the ID of a blog post on the page itself, I've made a small query to find it into the page. Open your browser console on the dev.to page of your article and paste the following:
 


### PR DESCRIPTION
The button now says "save changes" instead of "save draft".

<img width="332" alt="Screen Shot 2019-08-02 at 10 33 20 am" src="https://user-images.githubusercontent.com/7598058/62335954-65e3a500-b511-11e9-8b90-045e431366b1.png">