### PR TITLE
Fix missing "as data" in code example

### DIFF
--- a/blog-posts/angular-easily-extract-a-falsy-value-from-an-observable-using-the-async-pipe/angular-easily-extract-a-falsy-value-from-an-observable-using-the-async-pipe.md
+++ b/blog-posts/angular-easily-extract-a-falsy-value-from-an-observable-using-the-async-pipe/angular-easily-extract-a-falsy-value-from-an-observable-using-the-async-pipe.md
@@ -92,9 +92,9 @@ After:
     value1: value1$ | async,
     value2: value2$ | async,
     value3: value3$ | async
-  }"
+  } as data"
 >
-  {{ value1 }} {{ value2 }} {{ value3 }}
+  {{ data.value1 }} {{ data.value2 }} {{ data.value3 }}
 </div>
 ```
 


### PR DESCRIPTION
In: angular-easily-extract-a-falsy-value-from-an-observable-using-the-async-pipe.md